### PR TITLE
Define querystring

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var https = require('https');
-var querystring = require('querystring');
 var util = require('./util.js');
 
 exports.search = function(search_string, options, callback) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,6 +2,7 @@
 
 var Entities = require('html-entities').AllHtmlEntities;
 var url = require('url');
+var querystring = require('querystring');
 var base_url = 'https://www.youtube.com/results?';
 
 exports.build_link = function(query) {


### PR DESCRIPTION
Without this fix, script will crash if user doesn't define `querystring` themselves