### PR TITLE
Parse videos provided by 3rd party correctly

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -132,6 +132,7 @@ exports.parseVideo = string => {
     .replace(/<\/li>/g, '')
     .split('<li>')
     .splice(1);
+  if (metaInfo.length == 1) metaInfo.unshift(null);
   const live = string.includes('yt-badge-live" >Live now</span>');
   const live_views = metaInfo[0] ? parseInt(metaInfo[0].replace(/\.|,/g, '')) : 0;
   const thumbnailRaw = exports.between(string, 'data-thumb="', '"');

--- a/lib/util.js
+++ b/lib/util.js
@@ -132,7 +132,7 @@ exports.parseVideo = string => {
     .replace(/<\/li>/g, '')
     .split('<li>')
     .splice(1);
-  if (metaInfo.length == 1) metaInfo.unshift(null);
+  if (metaInfo.length === 1) metaInfo.unshift(null);
   const live = string.includes('yt-badge-live" >Live now</span>');
   const live_views = metaInfo[0] ? parseInt(metaInfo[0].replace(/\.|,/g, '')) : 0;
   const thumbnailRaw = exports.between(string, 'data-thumb="', '"');


### PR DESCRIPTION
Since it doesn't give upload information in the search result, we will just make it `null`

Example: [`Acchi Kocchi Tim & Puma Mimi - Topic`](https://www.youtube.com/results?search_query=Acchi+Kocchi+Tim+%26+Puma+Mimi+-+Topic)