### PR TITLE
Add missing colon to getFilters() type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -120,7 +120,7 @@ declare module 'ytsr' {
       currentRef: string | null;
     }
 
-    function getFilters(searchString: string, options? ytsr.Options): Promise<Map<string, Filter>>;
+    function getFilters(searchString: string, options?: ytsr.Options): Promise<Map<string, Filter>>;
   }
 
   function ytsr(id: string): Promise<ytsr.Result>;


### PR DESCRIPTION
The missing colon caused issues with vscode intellisense and let the typescript build fail when using the module.