### PR TITLE
patch getFilters

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -64,9 +64,9 @@ const main = module.exports = async(searchString, options) => {
 };
 
 main.getFilters = async(searchString, options) => {
-  if (!searchString || typeof(searchString) !== 'string') throw new Error('searchString is mandatory');
+  if (!searchString || typeof searchString !== 'string') throw new Error('searchString is mandatory');
 
-  // watch out for previous filter requests
+  // Watch out for previous filter requests
   // in such a case searchString would be an url including `sp` & `search_query` querys
   let prevQuery = URL.parse(searchString, true).query;
   const urlOptions = prevQuery ? Object.assign({}, options, prevQuery) : options;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,3 +1,4 @@
+const URL = require('url');
 const UTIL = require('./util.js');
 const PARSE_ITEM = require('./parseItem.js');
 const MINIGET = require('miniget');
@@ -63,9 +64,14 @@ const main = module.exports = async(searchString, options) => {
 };
 
 main.getFilters = async(searchString, options) => {
-  if (!searchString) throw new Error('searchString is mandatory');
+  if (!searchString || typeof(searchString) !== 'string') throw new Error('searchString is mandatory');
 
-  const ref = UTIL.buildRef(null, searchString, options);
+  // watch out for previous filter requests
+  // in such a case searchString would be an url including `sp` & `search_query` querys
+  let prevQuery = URL.parse(searchString, true).query;
+  const urlOptions = prevQuery ? Object.assign({}, options, prevQuery) : options;
+
+  const ref = UTIL.buildRef(null, prevQuery.search_query || searchString, urlOptions);
   const body = await MINIGET(ref, options).text();
   const parsed = JSON.parse(body);
   const content = parsed[parsed.length - 1].body.content;

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -49,13 +49,19 @@ describe('ytsr()', () => {
 
   it('errors when empty nextpageRef is provided', () => {
     YTSR('').catch(err => {
-      ASSERT.strictEqual(err.message, 'search string must be of type string');
+      ASSERT.strictEqual(err.message, 'search string or nextpageRef is mandatory');
     });
   });
 
   it('errors when empty query is provided', () => {
     YTSR(null, { nextpageRef: '' }).catch(err => {
-      ASSERT.strictEqual(err.message, 'nextpageRef must be of type string');
+      ASSERT.strictEqual(err.message, 'search string or nextpageRef is mandatory');
+    });
+  });
+
+  it('errors when query is not a string but "!!true"', () => {
+    YTSR({}).catch(err => {
+      ASSERT.strictEqual(err.message, 'search string must be of type string');
     });
   });
 

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -27,7 +27,7 @@ describe('ytsr#getFilters()', () => {
       ASSERT.strictEqual(
         err.message,
         'Nock: Disallowed net connect for \
-        "www.youtube.com:443/results?spf=navigate&gl=US&hl=en&search_query=some%20query"',
+"www.youtube.com:443/results?spf=navigate&gl=US&hl=en&search_query=some%20query"',
       );
       ASSERT.ok(resp instanceof Promise);
       done();

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -21,6 +21,14 @@ describe('ytsr#getFilters()', () => {
       done();
     });
   });
+
+  it('empty search string provided', done => {
+    let resp = YTSR.getFilters('https://www.youtube.com/results?search_query=some+query&sp=some_param').catch(err => {
+      ASSERT.strictEqual(err.message, 'Nock: Disallowed net connect for "www.youtube.com:443/results?spf=navigate&gl=US&hl=en&search_query=some%20query"');
+      ASSERT.ok(resp instanceof Promise);
+      done();
+    });
+  });
 });
 
 describe('ytsr()', () => {

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -24,7 +24,11 @@ describe('ytsr#getFilters()', () => {
 
   it('empty search string provided', done => {
     let resp = YTSR.getFilters('https://www.youtube.com/results?search_query=some+query&sp=some_param').catch(err => {
-      ASSERT.strictEqual(err.message, 'Nock: Disallowed net connect for "www.youtube.com:443/results?spf=navigate&gl=US&hl=en&search_query=some%20query"');
+      ASSERT.strictEqual(
+        err.message,
+        'Nock: Disallowed net connect for \
+        "www.youtube.com:443/results?spf=navigate&gl=US&hl=en&search_query=some%20query"',
+      );
       ASSERT.ok(resp instanceof Promise);
       done();
     });


### PR DESCRIPTION
to just quote zarlino#3039 from discord:

> I'm testing the new ytsr "rework". I'm getting an error when I use more than one filter.
> The first "ref" I get is https://www.youtube.com/results?search_query=jazz+trio&sp=EgIQAQ%253D%253D which looks ok
> The second one is https://www.youtube.com/results?search_query=https%3A%2F%2Fwww.youtube.com%2Fresults%3Fsearch_query%3Djazz%2Btrio%26sp%3DEgIQAQ%25253D%25253D&sp=EgIgAQ%253D%253D
> It seems like it is treating a filter.ref like a search string
