### PR TITLE
Fix duration and uploaded_at for live videos

### DIFF
--- a/lib/util_v2.js
+++ b/lib/util_v2.js
@@ -45,7 +45,7 @@ const parseItem = (item) => {
 
       views: upcoming ? null : item[type].viewCountText.simpleText || item[type].viewCountText.runs.map(a => a.text).join(''),
       duration: isLive || upcoming ? null : item[type].lengthText.simpleText ? item[type].lengthText.simpleText : null,
-      uploaded_at: isLive || upcoming ? null : item[type].publishedTimeText.simpleText ? item[type].publishedTimeText.simpleText : null,
+      uploaded_at: isLive || upcoming ? null : item[type].publishedTimeText ? item[type].publishedTimeText.simpleText : null,
     };
   } else if (type === 'shelfRenderer') {
     // console.log(item);

--- a/lib/util_v2.js
+++ b/lib/util_v2.js
@@ -41,11 +41,11 @@ const parseItem = (item) => {
         verified: Array.isArray(item[type].ownerBadges) && item[type].ownerBadges.some(a => a.metadataBadgeRenderer.tooltip === 'Verified'),
       },
 
-      description: item[type].descriptionSnippet.runs.map(a => a.text).join(''),
+      description: item[type].descriptionSnippet ? item[type].descriptionSnippet.runs.map(a => a.text).join('') : null,
 
       views: upcoming ? null : item[type].viewCountText.simpleText || item[type].viewCountText.runs.map(a => a.text).join(''),
-      duration: isLive || upcoming ? null : item[type].lengthText.simpleText,
-      uploaded_at: isLive || upcoming ? null : item[type].publishedTimeText.simpleText,
+      duration: isLive || upcoming ? null : item[type].lengthText.simpleText ? item[type].lengthText.simpleText : null,
+      uploaded_at: isLive || upcoming ? null : item[type].publishedTimeText.simpleText ? item[type].publishedTimeText.simpleText : null,
     };
   } else if (type === 'shelfRenderer') {
     // console.log(item);


### PR DESCRIPTION
When I was testing the search with the searchterm 'Mike' I ended up getting this object in the json:

```
    {
      "type": "video",
      "live": true,
      "title": "Mike Parry Sunday | 1pm-4pm | 25-October-20",
      "link": "https://www.youtube.com/watch?v=W5ZVPd-wsuo",
      "id": "W5ZVPd-wsuo",
      "thumbnail": "https://i.ytimg.com/vi/W5ZVPd-wsuo/hq720_live.jpg?sqp=-oaymwEXCNAFEJQDSFryq4qpAwkIARUAAIhCGAE=&rs=AOn4CLCOtTQ8tJQj9OP0YKtxJg-O-NA8fA",
      "author": {
        "name": "talkRADIO",
        "ref": "https://www.youtube.com/channel/UCm0yTweyAa0PwEIp0l3N_gA",
        "verified": false
      },
      "views": "573 watching",
      "duration": null,
      "uploaded_at": null
    }
```

Seems to be a live video that does not have a duration and uploaded_at value.
Without these changes the module will return an error

`TypeError: Cannot read property 'runs' of undefined
    at parseItem (/blablabla/node_modules/ytsr/lib/util_v2.js:44:50)`

`TypeError: Cannot read property 'simpleText' of undefined
    at parseItem (/blablabla/node_modules/ytsr/lib/util_v2.js:48:77)`

Are some of the errors me and other users have encountered