### PR TITLE
Fix for videos with no description / Temporary fix for non-existent published dates

### DIFF
--- a/lib/util_v2.js
+++ b/lib/util_v2.js
@@ -45,7 +45,7 @@ const parseItem = (item) => {
 
       views: upcoming ? null : item[type].viewCountText.simpleText || item[type].viewCountText.runs.map(a => a.text).join(''),
       duration: isLive || upcoming ? null : item[type].lengthText.simpleText,
-      uploaded_at: isLive || upcoming ? null : item[type].publishedTimeText.simpleText,
+      uploaded_at: isLive || upcoming || !item[type].publishedTimeText ? null : item[type].publishedTimeText.simpleText,
     };
   } else if (type === 'shelfRenderer') {
     // console.log(item);

--- a/lib/util_v2.js
+++ b/lib/util_v2.js
@@ -41,7 +41,7 @@ const parseItem = (item) => {
         verified: Array.isArray(item[type].ownerBadges) && item[type].ownerBadges.some(a => a.metadataBadgeRenderer.tooltip === 'Verified'),
       },
 
-      description: item[type].descriptionSnippet.runs.map(a => a.text).join(''),
+      description: item[type].descriptionSnippet ? item[type].descriptionSnippet.runs.map(a => a.text).join('') : '',
 
       views: upcoming ? null : item[type].viewCountText.simpleText || item[type].viewCountText.runs.map(a => a.text).join(''),
       duration: isLive || upcoming ? null : item[type].lengthText.simpleText,


### PR DESCRIPTION
Some videos are lacking the information regarding the published dates. Not sure why exactly that's happening but this should at least prevent errors from occurring.

This should solve FreeTubeApp/FreeTube#718