### PR TITLE
Clone and edit options object instead of the original one

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -74,9 +74,9 @@ const parseText = exports.parseText = txt => txt.simpleText || txt.runs.map(a =>
 exports.parseIntegerFromText = txt => Number(parseText(txt).replace(/\D+/g, ''));
 
 // Request Utility
-exports.doPost = async(url, reqOpts, payload) => {
+exports.doPost = async(url, opts, payload) => {
   // Enforce POST-Request
-  reqOpts.method = 'POST';
+  const reqOpts = Object.assign({}, opts, { method: 'POST' });
   const req = MINIGET(url, reqOpts);
   // Write request body
   req.once('request', r => r.write(JSON.stringify(payload)));


### PR DESCRIPTION
If using `requestOptions` option and not re-generating options object