### PR TITLE
Added video meta description to video search result objects with hashtag fix

### DIFF
--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -155,6 +155,7 @@ const parseVideo = obj => {
     } : null,
 
     description: UTIL.parseText(obj.descriptionSnippet),
+    metaDescription: obj.detailedMetadataSnippets[0]?.snippetText?.runs[0]?.text ?? null,
 
     views: !obj.viewCountText ? null : UTIL.parseIntegerFromText(obj.viewCountText),
     // Duration not provided for live & sometimes with upcoming & sometimes randomly

--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -155,7 +155,7 @@ const parseVideo = obj => {
     } : null,
 
     description: UTIL.parseText(obj.descriptionSnippet),
-    metaDescription: obj.detailedMetadataSnippets[0]?.snippetText?.runs[0]?.text ?? null,
+    metaDescription: obj.detailedMetadataSnippets?.[0]?.snippetText?.runs[0]?.text ?? null,
 
     views: !obj.viewCountText ? null : UTIL.parseIntegerFromText(obj.viewCountText),
     // Duration not provided for live & sometimes with upcoming & sometimes randomly

--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -122,7 +122,7 @@ const parseVideo = obj => {
       author.navigationEndpoint.commandMetadata.webCommandMetadata.url;
   }
   const badges = Array.isArray(obj.badges) ? obj.badges.map(a => a.metadataBadgeRenderer.label) : [];
-  const isLive = badges.some(b => b === 'LIVE NOW');
+  const isLive = badges.some(b => b.match(/^live$/i) || b.match(/^live now$/i));
   const upcoming = obj.upcomingEventData ? Number(`${obj.upcomingEventData.startTime}000`) : null;
   const ctsr = obj.channelThumbnailSupportedRenderers;
   const authorImg = !ctsr ? { thumbnail: { thumbnails: [] } } : ctsr.channelThumbnailWithLinkRenderer;

--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -32,6 +32,8 @@ const parseItem = (item, resp) => {
       return parseShelf(item[type]);
     case 'showRenderer':
       return parseShow(item[type]);
+    case 'hashtagTileRenderer':
+      return parseHashtag(item[type])
 
     // Change resp#refinements or resp#resultsFor
     case 'didYouMeanRenderer':
@@ -410,6 +412,16 @@ const parseShelf = obj => {
   };
 };
 
+const parseHashtag = obj => {
+  return {
+    type: 'hashtag',
+    hashtag: UTIL.parseText(obj.hashtag),
+    videoCount: UTIL.parseText(obj.hashtagVideoCount),
+    channelCount: UTIL.parseText(obj.hashtagChannelCount),
+    url: obj.onTapCommand.commandMetadata.webCommandMetadata.url,
+    thumbnails: obj.hashtagThumbnail.thumbnails
+  }
+}
 /**
  * Generalised Method
  *

--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -122,7 +122,7 @@ const parseVideo = obj => {
       author.navigationEndpoint.commandMetadata.webCommandMetadata.url;
   }
   const badges = Array.isArray(obj.badges) ? obj.badges.map(a => a.metadataBadgeRenderer.label) : [];
-  const isLive = badges.some(b => b.match(/^live$/i) || b.match(/^live now$/i));
+  const isLive = badges.some(b => b.match(/^(live|live now)$/i));
   const upcoming = obj.upcomingEventData ? Number(`${obj.upcomingEventData.startTime}000`) : null;
   const ctsr = obj.channelThumbnailSupportedRenderers;
   const authorImg = !ctsr ? { thumbnail: { thumbnails: [] } } : ctsr.channelThumbnailWithLinkRenderer;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -212,7 +212,18 @@ declare module 'ytsr' {
       }[];
     }
 
-    type Item = Video | Channel | Playlist | Mix | GridMovie | Movie | Show | Shelf | Clarification | HorizontalChannelList;
+    interface Hashtag {
+      type: 'hashtag'
+      hashtag: string
+      videoCount: string
+      channelCount: string
+      url: string
+      thumbnails: [
+        url: string
+      ]
+    }
+
+    type Item = Video | Channel | Playlist | Mix | GridMovie | Movie | Show | Shelf | Clarification | HorizontalChannelList | Hashtag;
 
     /**
      * @param searchString search query or link from a previous getFilters request


### PR DESCRIPTION
Noticed that while the API doesn't return the true video description it *does* return its meta description, so I've included that in the video search results. Also this was forked from @ChunkyProgrammer's hashtag fix branch, so that's included too. 