### PR TITLE
fix(ads): Add reelPlayerHeaderRenderer

### DIFF
--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -55,7 +55,13 @@ const parseItem = (item, resp) => {
     case 'clarificationRenderer':
       return parseClarification(item[type]);
 
+<<<<<<< Updated upstream
     // Skip Adds for now
+=======
+    // Skip Ads for now
+    case 'reelPlayerHeaderRenderer':
+    case 'adSlotRenderer':
+>>>>>>> Stashed changes
     case 'carouselAdRenderer':
     case 'searchPyvRenderer':
     case 'promotedVideoRenderer':

--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -55,13 +55,9 @@ const parseItem = (item, resp) => {
     case 'clarificationRenderer':
       return parseClarification(item[type]);
 
-<<<<<<< Updated upstream
-    // Skip Adds for now
-=======
     // Skip Ads for now
     case 'reelPlayerHeaderRenderer':
     case 'adSlotRenderer':
->>>>>>> Stashed changes
     case 'carouselAdRenderer':
     case 'searchPyvRenderer':
     case 'promotedVideoRenderer':


### PR DESCRIPTION
Add `reelPlayerHeaderRenderer` to the Skip ads case block.
Must be a new thing YouTube added that's not yet handled.

closes #174 
closes #171 