### PR TITLE
Catch and log fix

### DIFF
--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -89,6 +89,12 @@ const catchAndLogFunc = (func, params = []) => {
   try {
     return func(...params);
   } catch (e) {
+
+    const dir = PATH.resolve(__dirname, '../dumps/');
+    const file = PATH.resolve(dir, `${Math.random().toString(36).substr(3)}-${Date.now()}.txt`);
+    const cfg = PATH.resolve(__dirname, '../package.json');
+    const bugsRef = require(cfg).bugs.url;
+
     /* eslint-disable no-console */
     console.error(e.stack);
     console.error(`\n/${'*'.repeat(200)}`);
@@ -100,11 +106,6 @@ const catchAndLogFunc = (func, params = []) => {
     console.error(info);
     console.error(`${'*'.repeat(200)}\\`);
     /* eslint-enable no-console */
-
-    const dir = PATH.resolve(__dirname, '../dumps/');
-    const file = PATH.resolve(dir, `${Math.random().toString(36).substr(3)}-${Date.now()}.txt`);
-    const cfg = PATH.resolve(__dirname, '../package.json');
-    const bugsRef = require(cfg).bugs.url;
 
     try {
       if (!FS.existsSync(dir)) FS.mkdirSync(dir);

--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -89,13 +89,6 @@ const catchAndLogFunc = (func, params = []) => {
   try {
     return func(...params);
   } catch (e) {
-    const dir = PATH.resolve(__dirname, '../dumps/');
-    const file = PATH.resolve(dir, `${Math.random().toString(36).substr(3)}-${Date.now()}.txt`);
-    const cfg = PATH.resolve(__dirname, '../package.json');
-    const bugsRef = require(cfg).bugs.url;
-
-    if (!FS.existsSync(dir)) FS.mkdirSync(dir);
-    FS.writeFileSync(file, JSON.stringify(params, null, 2));
     /* eslint-disable no-console */
     console.error(e.stack);
     console.error(`\n/${'*'.repeat(200)}`);
@@ -107,6 +100,19 @@ const catchAndLogFunc = (func, params = []) => {
     console.error(info);
     console.error(`${'*'.repeat(200)}\\`);
     /* eslint-enable no-console */
+
+    const dir = PATH.resolve(__dirname, '../dumps/');
+    const file = PATH.resolve(dir, `${Math.random().toString(36).substr(3)}-${Date.now()}.txt`);
+    const cfg = PATH.resolve(__dirname, '../package.json');
+    const bugsRef = require(cfg).bugs.url;
+
+    try {
+      if (!FS.existsSync(dir)) FS.mkdirSync(dir);
+      FS.writeFileSync(file, JSON.stringify(params, null, 2));
+    } catch(e) {
+      console.warn("Could not write dumps to file:", e);
+    }
+
     return null;
   }
 };

--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -89,7 +89,6 @@ const catchAndLogFunc = (func, params = []) => {
   try {
     return func(...params);
   } catch (e) {
-
     const dir = PATH.resolve(__dirname, '../dumps/');
     const file = PATH.resolve(dir, `${Math.random().toString(36).substr(3)}-${Date.now()}.txt`);
     const cfg = PATH.resolve(__dirname, '../package.json');
@@ -110,8 +109,8 @@ const catchAndLogFunc = (func, params = []) => {
     try {
       if (!FS.existsSync(dir)) FS.mkdirSync(dir);
       FS.writeFileSync(file, JSON.stringify(params, null, 2));
-    } catch(e) {
-      console.warn("Could not write dumps to file:", e);
+    } catch (e2) {
+      console.warn('Could not write dumps to file:', e2);
     }
 
     return null;


### PR DESCRIPTION
I was getting a `EACCES: permission denied` error when it tried to create the dump file.
I think that it would be better if it would log the error first and then create the dump file, and in case it can't, log the error to the console. This is because if the error appeared when writting the file, it would neither write the file nor log the error.