### PR TITLE
Potentially fixes #196

### DIFF
--- a/lib/parseItem.js
+++ b/lib/parseItem.js
@@ -117,9 +117,9 @@ main._hidden = { catchAndLogFunc, parseItem };
 const parseVideo = obj => {
   const author = obj.ownerText && obj.ownerText.runs[0];
   let authorUrl = null;
-  if (author) {
-    authorUrl = author.navigationEndpoint.browseEndpoint.canonicalBaseUrl ||
-      author.navigationEndpoint.commandMetadata.webCommandMetadata.url;
+  if (author && author.navigationEndpoint) {
+    authorUrl = author.navigationEndpoint.browseEndpoint?.canonicalBaseUrl ||
+      author.navigationEndpoint.commandMetadata?.webCommandMetadata.url;
   }
   const badges = Array.isArray(obj.badges) ? obj.badges.map(a => a.metadataBadgeRenderer.label) : [];
   const isLive = badges.some(b => b === 'LIVE NOW');
@@ -201,7 +201,7 @@ const parsePlaylist = obj => ({
   } : null,
 
   // Some Playlists starting with OL only provide a simple string
-  owner: obj.shortBylineText.simpleText ? null : _parseOwner(obj),
+  owner: obj.shortBylineText?.simpleText ? null : _parseOwner(obj),
 
   publishedAt: UTIL.parseText(obj.publishedTimeText),
   length: Number(obj.videoCount),
@@ -428,7 +428,10 @@ const parseShelf = obj => {
 const _parseOwner = obj => {
   const owner = (obj.shortBylineText && obj.shortBylineText.runs[0]) ||
     (obj.longBylineText && obj.longBylineText.runs[0]);
-  const ownerUrl = owner.navigationEndpoint.browseEndpoint.canonicalBaseUrl ||
+  if(!owner) { 
+    return null 
+  }
+  const ownerUrl = owner.navigationEndpoint.browseEndpoint?.canonicalBaseUrl ||
     owner.navigationEndpoint.commandMetadata.webCommandMetadata.url;
   const isOfficial = !!(obj.ownerBadges && JSON.stringify(obj.ownerBadges).includes('OFFICIAL'));
   const isVerified = !!(obj.ownerBadges && JSON.stringify(obj.ownerBadges).includes('VERIFIED'));


### PR DESCRIPTION
I was getting this error when searching for a song by Cameo: `Fast, Fierce & Funny Cameo audio`
I got the error
```
 Cannot read properties of undefined (reading 'simpleText') #196 
```
I made the change on line `204`  and got a new error where could not read properties of undefined reading `canonicalBaseUrl`

Based on my understanding of the code base these changes should be safe. Please let me know if otherwise.