### PR TITLE
fix: address filterWrapper is not iterable error

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,11 @@ const DEFAULT_CONTEXT = {
 exports.parseFilters = json => {
   const pc = json.contents.twoColumnSearchResultsRenderer.primaryContents;
   const wrapper = pc.sectionListRenderer || pc.richGridRenderer;
-  const filterWrapper = (wrapper.subMenu || wrapper.submenu).searchSubMenuRenderer.groups || [];
+  let filterWrapper = (wrapper.subMenu || wrapper.submenu).searchSubMenuRenderer.groups;
+  if (filterWrapper === undefined) {
+    const pc1 = json.header.searchHeaderRenderer.searchFilterButton.buttonRenderer.command.openPopupAction.popup;
+    filterWrapper = pc1.searchFilterOptionsDialogRenderer.groups || [];
+  }
   const parsedGroups = new Map();
   for (const filterGroup of filterWrapper) {
     const singleFilterGroup = new Map();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,7 @@ const DEFAULT_CONTEXT = {
 exports.parseFilters = json => {
   const pc = json.contents.twoColumnSearchResultsRenderer.primaryContents;
   const wrapper = pc.sectionListRenderer || pc.richGridRenderer;
-  const filterWrapper = (wrapper.subMenu || wrapper.submenu).searchSubMenuRenderer.groups;
+  const filterWrapper = (wrapper.subMenu || wrapper.submenu).searchSubMenuRenderer.groups || [];
   const parsedGroups = new Map();
   for (const filterGroup of filterWrapper) {
     const singleFilterGroup = new Map();


### PR DESCRIPTION
Addresses [issue#206](https://github.com/TimeForANinja/node-ytsr/issues/206)

A quick and technically not ideal fix. This change adds a safety check so that if `wrapper.subMenu` returns undefined, then the method returns an empty filter map, instead of throwing an error. This will likely always be the case now and this code does not address the root issue.

The fact of the matter is that YouTube likely updated their payload data (thus breaking the filter feature). The main fix would be updating the path to `searchFilterGroupRenderer`, which still exists. The point of this PR, at the very least, is to add a safety check to allow for YTSR to return search data, which is much better than not returning anything at all whenever YouTube updates their response.  


Furthermore, I did take a look into the new payload and found that filter data could maybe be retrieved like this: 

```
exports.parseFilters = json => {
  const pc = json.header.searchHeaderRenderer.searchFilterButton.buttonRenderer.command.openPopupAction.popup;
  const filterWrapper = pc.searchFilterOptionsDialogRenderer.groups || [];
  const parsedGroups = new Map();
...
```

I did not make a PR with this code (yet) for a few reasons. ~~Firstly because all the tests that rely on local HTML data fail,  because this code only expects the new payload format~~. Also the typings have to be updated. 

Update: 
I updated the code to support both the old and new payload formats.

Thanks,
Reply2za

